### PR TITLE
Preliminary support for 0xfdcb and 0xddcb bit operations

### DIFF
--- a/udis.py
+++ b/udis.py
@@ -26,6 +26,7 @@ import signal
 
 pcr = 1
 und = 2
+z80bit = 4
 
 # Functions
 
@@ -195,7 +196,14 @@ while True:
         elif length == 2:
             operand = format.format(op[1])
         elif length == 3:
-            operand = format.format(op[1], op[2])
+            if flags & 4 == z80bit:
+                opcode = (opcode << 16) + op[2]
+                # reread opcode table for real format string
+                length, mnemonic, mode = opcodeTable[opcode]
+                format = addressModeTable[mode]
+                operand = format.format(op[1])
+            else:
+                operand = format.format(op[1], op[2])
         elif length == 4:
             operand = format.format(op[1], op[2], op[3])
         elif length == 5:

--- a/udis.py
+++ b/udis.py
@@ -199,7 +199,7 @@ while True:
             if flags & 4 == z80bit:
                 opcode = (opcode << 16) + op[2]
                 # reread opcode table for real format string
-                length, mnemonic, mode = opcodeTable[opcode]
+                length, mnemonic, mode, flags = opcodeTable[opcode]
                 format = addressModeTable[mode]
                 operand = format.format(op[1])
             else:

--- a/udis.py
+++ b/udis.py
@@ -182,7 +182,7 @@ while True:
         # Handle relative addresses. Indicated by the flag pcr being set.
         # Assumes the operand that needs to be PC relative is the last one.
         # Note: Code will need changes if more flags are added.
-        if flags & 1 == pcr:
+        if flags & pcr:
             if op[length-1] < 128:
                 op[length-1] = address + op[length-1] + length
             else:
@@ -196,7 +196,7 @@ while True:
         elif length == 2:
             operand = format.format(op[1])
         elif length == 3:
-            if flags & 4 == z80bit:
+            if flags & z80bit:
                 opcode = (opcode << 16) + op[2]
                 # reread opcode table for real format string
                 length, mnemonic, mode, flags = opcodeTable[opcode]

--- a/z80.py
+++ b/z80.py
@@ -1005,7 +1005,7 @@ def extra_opcodes(addr_table, op_table):
         
         for fourth_byte, (instruction, addrmode) in enumerate(zip(mnemonics, addrmodes)):
             opcode = (first_byte << 24) + (0xcb << 16) + fourth_byte
-            op_table[opcode] = [ 4, instruction, addrmode % x_or_y ]
+            op_table[opcode] = [ 4, instruction, addrmode % x_or_y, z80bit ]
 extra_opcodes(addressModeTable, opcodeTable)
 del extra_opcodes
 

--- a/z80.py
+++ b/z80.py
@@ -297,7 +297,6 @@ addressModeTable = {
 "z"          : "z",
 "z,pcr"      : "z,${0:04X}",
 "z,nn"       : "z,${1:02X}{0:02X}",
-"bit"        : "${0:02X},${1:02X}",
 }
 
 # Op Code Table

--- a/z80.py
+++ b/z80.py
@@ -297,6 +297,7 @@ addressModeTable = {
 "z"          : "z",
 "z,pcr"      : "z,${0:04X}",
 "z,nn"       : "z,${1:02X}{0:02X}",
+"bit"        : "${0:02X},${1:02X}",
 }
 
 
@@ -882,7 +883,7 @@ opcodeTable = {
 
 # The below are a set of instructions that all start with 0xddcb. They
 # are not supported yet.
-0xddcb : [ 4, "unimplemented",  "implied" ],
+0xddcb : [ 4, "ixbit",  "bit"    ],
 
 0xed40 : [ 2, "in",   "b,indc"   ],
 0xed41 : [ 2, "out",  "indc,b"   ],
@@ -978,7 +979,7 @@ opcodeTable = {
 
 # The below are a set of instructions that all start with 0xfdcb. They
 # are not supported yet.
-0xfdcb : [ 4, "unimplemented",  "implied" ],
+0xfdcb : [ 4, "iybit",  "bit"     ],
 
 }
 


### PR DESCRIPTION
I've added preliminary support for the 512 operations defined by the 4-byte 0xfdcb and 0xddcb opcodes. It may or may not be the way you want to implement them, but it's a start, at least. Rather than hand coding 512 entries to the opcodeTable and 56 to the addressModeTable, I've created a helper function that creates those entries from all the logical combinations.

Because the 3rd byte contains the offset and the 4th specifies the addressing mode, I couldn't think of any other way to support it than adding a flag and handle it as a special case in the disassembler. The helper function adds a 4 byte value as the opcode key, but always sets the 3rd byte as zero leaving it for the special case handling to fill in the correct 3rd byte.

One problem I'm having is the addressing modes are defined like `(ix+${0:02X}),a`, but in reading the z80 docs, it appears the offset value is signed with a range -128 to 127, so the addressing modes should actually be `(ix-${0:02X}),a` when the values are negative. I have no idea how to handle that other than adding another check for another special case.
